### PR TITLE
Small clean up for multi-gpu cuda availability checking

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,7 +35,8 @@ class CheckEnvironmentWork(LightningWork):
             self.python = True
         else:
             self.python = setup.setup_python_environment()
-        self.cuda, self.devices = setup.check_cuda_available()
+        self.devices = setup.check_cuda_devices_available()
+        self.cuda = self.devices > 0
         self.internet = setup.sufficient_internet()
         self.memory = setup.sufficient_memory()
         self.bandwidth = str(setup.bandwidth()) + "GB/s"


### PR DESCRIPTION
Rename cuda check to cuda device check and have it return an int
how many devices PyTorch sees.

Also a small fix to the warning message logic.