### PR TITLE
Multiprocessing Guard

### DIFF
--- a/app.py
+++ b/app.py
@@ -172,4 +172,5 @@ class RootFlow(LightningFlow):
         return tabs
 
 
-app = LightningApp(root=RootFlow())
+if __name__ == "__main__":
+    app = LightningApp(root=RootFlow())


### PR DESCRIPTION
Prevents multiprocessing from failing by guarding the executed code with `if __name__ == "__main__"`